### PR TITLE
Fix cached user information after login

### DIFF
--- a/Resources/Private/Fusion/Components/Atoms/AccountProps.fusion
+++ b/Resources/Private/Fusion/Components/Atoms/AccountProps.fusion
@@ -22,5 +22,14 @@ prototype(Networkteam.Neos.FrontendLogin:Components.Atoms.AccountProps) < protot
         }
     }
 
+    @cache {
+        mode = 'uncached'
+        context {
+            1 = 'node'
+            2 = 'documentNode'
+            3 = 'site'
+        }
+    }
+
     renderer = ''
 }


### PR DESCRIPTION
The LoginStatus showed cached user information after switching logins when displaying user/account information.